### PR TITLE
translatable findOneBy repository method

### DIFF
--- a/lib/FSi/DoctrineExtensions/Exception/ConditionException.php
+++ b/lib/FSi/DoctrineExtensions/Exception/ConditionException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace FSi\DoctrineExtensions\Exception;
+
+class ConditionException extends \Exception implements ExceptionInterface
+{
+    
+} 

--- a/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/Article.php
+++ b/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/Article.php
@@ -44,14 +44,34 @@ class Article
     private $title;
 
     /**
+     * @Translatable\Translatable(mappedBy="translations", targetField="introduction")
+     * @var string
+     */
+    private $teaser;
+
+    /**
      * @Translatable\Translatable(mappedBy="translations")
      * @var string
      */
     private $contents;
 
     /**
+     * @var Section
+     *
+     * @ORM\ManyToOne(targetEntity="Section", inversedBy="articles")
+     */
+    private $section;
+
+    /**
+     * @var ArrayCollection|Comment[]
+     *
+     * @ORM\OneToMany(targetEntity="Comment", mappedBy="article")
+     */
+    private $comments;
+
+    /**
      * @ORM\OneToMany(targetEntity="ArticleTranslation", mappedBy="article", indexBy="locale")
-     * @var Doctrine\Common\Collections\ArrayCollection
+     * @var \Doctrine\Common\Collections\ArrayCollection
      */
     private $translations;
 
@@ -77,6 +97,22 @@ class Article
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTeaser()
+    {
+        return $this->teaser;
+    }
+
+    /**
+     * @param string $teaser
+     */
+    public function setTeaser($teaser)
+    {
+        $this->teaser = $teaser;
     }
 
     public function setDate(\DateTime $date)
@@ -137,5 +173,21 @@ class Article
     public function getTranslations()
     {
         return $this->translations;
+    }
+
+    /**
+     * @return Section
+     */
+    public function getSection()
+    {
+        return $this->section;
+    }
+
+    /**
+     * @param Section $section
+     */
+    public function setSection($section)
+    {
+        $this->section = $section;
     }
 }

--- a/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/ArticleTranslation.php
+++ b/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/ArticleTranslation.php
@@ -39,6 +39,12 @@ class ArticleTranslation
     private $title;
 
     /**
+     * @ORM\Column(nullable=true)
+     * @var string
+     */
+    private $introduction;
+
+    /**
      * @ORM\Column
      * @var string
      */
@@ -47,7 +53,7 @@ class ArticleTranslation
     /**
      * @ORM\ManyToOne(targetEntity="Article", inversedBy="translations")
      * @ORM\JoinColumn(name="article", referencedColumnName="id")
-     * @var Doctrine\Common\Collections\ArrayCollection
+     * @var \Doctrine\Common\Collections\ArrayCollection
      */
     private $article;
 
@@ -62,6 +68,22 @@ class ArticleTranslation
         return $this->title;
     }
 
+    /**
+     * @return string
+     */
+    public function getIntroduction()
+    {
+        return $this->introduction;
+    }
+
+    /**
+     * @param string $introduction
+     */
+    public function setIntroduction($introduction)
+    {
+        $this->introduction = $introduction;
+    }
+
     public function setContents($contents)
     {
         $this->contents = $contents;
@@ -73,15 +95,15 @@ class ArticleTranslation
         return $this->contents;
     }
 
-    public function setLocale($language)
+    public function setLocale($locale)
     {
-        $this->language = (string)$language;
+        $this->locale = (string) $locale;
         return $this;
     }
 
     public function getLocale()
     {
-        return $this->language;
+        return $this->locale;
     }
 
 }

--- a/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/Comment.php
+++ b/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/Comment.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\DoctrineExtensions\Tests\Translatable\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use FSi\DoctrineExtensions\Translatable\Mapping\Annotation as Translatable;
+
+/**
+ * @ORM\Entity
+ */
+class Comment
+{
+    /**
+     * @ORM\Column(name="id", type="bigint")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @var integer $id
+     */
+    private $id;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(type="datetime")
+     */
+    private $date;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column
+     */
+    private $content;
+
+    /**
+     * @var Article
+     *
+     * @ORM\ManyToOne(targetEntity="Article", inversedBy="comments")
+     */
+    private $article;
+
+    /**
+     * @param \FSi\DoctrineExtensions\Tests\Translatable\Fixture\Article $article
+     */
+    public function setArticle($article)
+    {
+        $this->article = $article;
+    }
+
+    /**
+     * @return \FSi\DoctrineExtensions\Tests\Translatable\Fixture\Article
+     */
+    public function getArticle()
+    {
+        return $this->article;
+    }
+
+    /**
+     * @param string $content
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param \DateTime $date
+     */
+    public function setDate($date)
+    {
+        $this->date = $date;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+}

--- a/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/Section.php
+++ b/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/Section.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * (c) FSi sp. z o.o. <info@fsi.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FSi\DoctrineExtensions\Tests\Translatable\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use FSi\DoctrineExtensions\Translatable\Mapping\Annotation as Translatable;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @ORM\Entity
+ */
+class Section
+{
+    /**
+     * @var integer $id
+     *
+     * @ORM\Column(name="id", type="bigint")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column
+     */
+    private $title;
+
+    /**
+     * @var ArrayCollection
+     *
+     * @ORM\OneToMany(targetEntity="Article", mappedBy="section")
+     */
+    private $articles;
+
+    public function __construct()
+    {
+        $this->articles = new ArrayCollection();
+    }
+
+    /**
+     * Get id
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getArticles()
+    {
+        return $this->articles;
+    }
+
+    /**
+     * @param mixed $articles
+     */
+    public function setArticles($articles)
+    {
+        $this->articles = $articles;
+    }
+}


### PR DESCRIPTION
this is proposition to add `findTranslatedOneBy` to `TranslatableRepository` that work similar to `findOneBy`
