### PR TITLE
Set an empty collection on null target fields when copying translation data

### DIFF
--- a/doc/translatable.md
+++ b/doc/translatable.md
@@ -102,16 +102,6 @@ class Article
     }
 
     /**
-     * @ORM\PostLoad()
-     * This is required, since doctrine will omit the __construct() method on
-     * loading the entity from the database and the `comments` field will be null.
-     */
-    public function postLoad()
-    {
-        $this->comments = new \Doctrine\Common\Collections\ArrayCollection();
-    }
-
-    /**
      * @return integer
      */
     public function getId()
@@ -194,9 +184,6 @@ class Article
     }
 }
 ```
-
-Please note the ``postLoad()`` method which is necessary to initialize translatable collection ``$comments`` before the
-real translated collection would be loaded from translation entity.
 
 The associated translation entity could be defined as follows:
 

--- a/lib/FSi/DoctrineExtensions/Translatable/ClassTranslationContext.php
+++ b/lib/FSi/DoctrineExtensions/Translatable/ClassTranslationContext.php
@@ -88,7 +88,8 @@ class ClassTranslationContext
 
         if (!($repository instanceof TranslatableRepositoryInterface)) {
             throw new Exception\AnnotationException(sprintf(
-                'Entity "%s" has "%s" as its "repositoryClass" which does not implement \FSi\DoctrineExtensions\Translatable\Model\TranslatableRepositoryInterface',
+                'Entity "%s" has "%s" as its "repositoryClass" which does not implement '
+                . '\FSi\DoctrineExtensions\Translatable\Model\TranslatableRepositoryInterface',
                 $this->classMetadata->getName(),
                 get_class($repository)
             ));

--- a/lib/FSi/DoctrineExtensions/Translatable/Mapping/ClassMetadata.php
+++ b/lib/FSi/DoctrineExtensions/Translatable/Mapping/ClassMetadata.php
@@ -10,7 +10,6 @@
 namespace FSi\DoctrineExtensions\Translatable\Mapping;
 
 use FSi\Component\Metadata\AbstractClassMetadata;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata as DoctrineClassMetadata;
 
 class ClassMetadata extends AbstractClassMetadata
 {
@@ -30,7 +29,7 @@ class ClassMetadata extends AbstractClassMetadata
      *
      * @param string $translationAssociation
      * @param string $property
-     * @param string $targetProperty
+     * @param string|null $targetField
      */
     public function addTranslatableProperty($translationAssociation, $property, $targetField = null)
     {

--- a/lib/FSi/DoctrineExtensions/Translatable/TranslatableListener.php
+++ b/lib/FSi/DoctrineExtensions/Translatable/TranslatableListener.php
@@ -178,7 +178,6 @@ class TranslatableListener extends MappedEventSubscriber
         }
 
         foreach ($translatableMeta->getTranslationAssociationMetadatas() as $associationMeta) {
-
             $context = $this->getTranslationContext($objectManager, $associationMeta, $object);
             $associationName = $associationMeta->getAssociationName();
             $repository = $context->getTranslatableRepository();
@@ -310,7 +309,7 @@ class TranslatableListener extends MappedEventSubscriber
 
             $context = $this->getTranslationContext($objectManager, $associationMeta, $object);
             $locale = $this->translationHelper->getObjectLocale($context, $object);
-            if (!isset($locale)) {
+            if (is_null($locale) || $locale === '') {
                 $locale = $this->getLocale();
             }
 

--- a/lib/FSi/DoctrineExtensions/Translatable/TranslatableListener.php
+++ b/lib/FSi/DoctrineExtensions/Translatable/TranslatableListener.php
@@ -15,33 +15,28 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Event\PreFlushEventArgs;
 use FSi\Component\Metadata\ClassMetadataInterface;
 use FSi\DoctrineExtensions\Mapping\MappedEventSubscriber;
-use FSi\DoctrineExtensions\Translatable\Entity\Repository\TranslatableRepository;
 use FSi\DoctrineExtensions\Translatable\Exception;
 use FSi\DoctrineExtensions\Translatable\Mapping\ClassMetadata as TranslatableClassMetadata;
 use FSi\DoctrineExtensions\Translatable\Mapping\TranslationAssociationMetadata;
-use FSi\DoctrineExtensions\Translatable\Model\TranslatableRepositoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 class TranslatableListener extends MappedEventSubscriber
 {
     /**
-     * @var \Symfony\Component\PropertyAccess\PropertyAccessor
+     * @var PropertyAccessor
      */
-    private $_propertyAccessor;
+    private $propertyAccessor;
 
     /**
-     * Current locale of the listener
-     *
-     * @var mixed
+     * @var string|null
      */
-    private $_currentLocale;
+    private $currentLocale;
 
     /**
-     * Default locale of the listener used when there is no translation in current locale
-     *
-     * @var mixed
+     * @var string|null
      */
-    private $_defaultLocale;
+    private $defaultLocale;
 
     /**
      * @var TranslationHelper
@@ -66,7 +61,7 @@ class TranslatableListener extends MappedEventSubscriber
      */
     public function setLocale($locale)
     {
-        $this->_currentLocale = $locale;
+        $this->currentLocale = $locale;
         return $this;
     }
 
@@ -75,7 +70,7 @@ class TranslatableListener extends MappedEventSubscriber
      */
     public function getLocale()
     {
-        return $this->_currentLocale;
+        return $this->currentLocale;
     }
 
     /**
@@ -84,7 +79,7 @@ class TranslatableListener extends MappedEventSubscriber
      */
     public function setDefaultLocale($defaultLocale)
     {
-        $this->_defaultLocale = $defaultLocale;
+        $this->defaultLocale = $defaultLocale;
         return $this;
     }
 
@@ -93,7 +88,7 @@ class TranslatableListener extends MappedEventSubscriber
      */
     public function getDefaultLocale()
     {
-        return $this->_defaultLocale;
+        return $this->defaultLocale;
     }
 
     /**
@@ -155,13 +150,13 @@ class TranslatableListener extends MappedEventSubscriber
     public function preFlush(PreFlushEventArgs $eventArgs)
     {
         $entityManager = $eventArgs->getEntityManager();
-        $unitOfWork    = $entityManager->getUnitOfWork();
+        $unitOfWork = $entityManager->getUnitOfWork();
 
         foreach ($unitOfWork->getScheduledEntityInsertions() as $object) {
             $this->updateObjectTranslations($entityManager, $object);
         }
 
-        foreach ($unitOfWork->getIdentityMap() as $class => $entities) {
+        foreach ($unitOfWork->getIdentityMap() as $entities) {
             foreach ($entities as $object) {
                 $this->updateObjectTranslations($entityManager, $object);
             }
@@ -190,9 +185,9 @@ class TranslatableListener extends MappedEventSubscriber
             $translation = $repository->findTranslation($object, $locale, $associationName);
 
             //default locale fallback
-            if (!isset($translation) && isset($this->_defaultLocale) && $this->_defaultLocale !== $locale) {
-                $locale = $this->_defaultLocale;
-                $translation = $repository->findTranslation($object, $this->_defaultLocale, $associationName);
+            if (!isset($translation) && isset($this->defaultLocale) && $this->defaultLocale !== $locale) {
+                $locale = $this->defaultLocale;
+                $translation = $repository->findTranslation($object, $this->defaultLocale, $associationName);
             }
 
             if (isset($translation)) {
@@ -221,28 +216,32 @@ class TranslatableListener extends MappedEventSubscriber
      */
     private function getPropertyAccessor()
     {
-        if (!isset($this->_propertyAccessor)) {
-            $this->_propertyAccessor = PropertyAccess::createPropertyAccessor();
+        if (!isset($this->propertyAccessor)) {
+            $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
         }
 
-        return $this->_propertyAccessor;
+        return $this->propertyAccessor;
     }
 
     /**
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $baseClassMetadata
-     * @param \FSi\DoctrineExtensions\Translatable\Mapping\ClassMetadata $translatableClassMetadata
+     * @param ClassMetadata $baseClassMetadata
+     * @param TranslatableClassMetadata $translatableClassMetadata
      * @throws \FSi\DoctrineExtensions\Translatable\Exception\MappingException
      */
-    private function validateTranslatableLocaleProperty(ClassMetadata $baseClassMetadata, TranslatableClassMetadata $translatableClassMetadata)
-    {
+    private function validateTranslatableLocaleProperty(
+        ClassMetadata $baseClassMetadata,
+        TranslatableClassMetadata $translatableClassMetadata
+    ) {
         if (!isset($translatableClassMetadata->localeProperty)) {
             throw new Exception\MappingException(sprintf(
                 "Entity '%s' has translatable properties so it must have property marked with @Translatable\\Language annotation",
                 $baseClassMetadata->getName()
             ));
         }
-        if ($baseClassMetadata->hasField($translatableClassMetadata->localeProperty) ||
-            $baseClassMetadata->hasAssociation($translatableClassMetadata->localeProperty)) {
+
+        if ($baseClassMetadata->hasField($translatableClassMetadata->localeProperty)
+            || $baseClassMetadata->hasAssociation($translatableClassMetadata->localeProperty)
+        ) {
             throw new Exception\MappingException(sprintf(
                 "Entity '%s' seems to be a translatable entity so its '%s' field must not be persistent",
                 $baseClassMetadata->getName(),
@@ -252,8 +251,8 @@ class TranslatableListener extends MappedEventSubscriber
     }
 
     /**
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $baseClassMetadata
-     * @param \FSi\DoctrineExtensions\Translatable\Mapping\ClassMetadata $translatableClassMetadata
+     * @param ClassMetadata $baseClassMetadata
+     * @param TranslatableClassMetadata $translatableClassMetadata
      * @throws \FSi\DoctrineExtensions\Translatable\Exception\MappingException
      */
     private function validateTranslatableProperties(
@@ -261,9 +260,10 @@ class TranslatableListener extends MappedEventSubscriber
         TranslatableClassMetadata $translatableClassMetadata
     ) {
         $translatableProperties = $translatableClassMetadata->getTranslatableProperties();
-        foreach ($translatableProperties as $translation => $properties) {
-            if (!$baseClassMetadata->hasAssociation($translation) ||
-                !$baseClassMetadata->isCollectionValuedAssociation($translation)) {
+        foreach (array_keys($translatableProperties) as $translation) {
+            if (!$baseClassMetadata->hasAssociation($translation)
+                || !$baseClassMetadata->isCollectionValuedAssociation($translation)
+            ) {
                 throw new Exception\MappingException(sprintf(
                     "Field '%s' in entity '%s' has to be a OneToMany association",
                     $translation,
@@ -274,14 +274,17 @@ class TranslatableListener extends MappedEventSubscriber
     }
 
     /**
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $baseClassMetadata
-     * @param \FSi\DoctrineExtensions\Translatable\Mapping\ClassMetadata $translatableClassMetadata
+     * @param ClassMetadata $baseClassMetadata
+     * @param TranslatableClassMetadata $translatableClassMetadata
      * @throws \FSi\DoctrineExtensions\Translatable\Exception\MappingException
      */
-    private function validateTranslationLocaleProperty(ClassMetadata $baseClassMetadata, TranslatableClassMetadata $translatableClassMetadata)
-    {
-        if (!$baseClassMetadata->hasField($translatableClassMetadata->localeProperty) &&
-            !$baseClassMetadata->hasAssociation($translatableClassMetadata->localeProperty)) {
+    private function validateTranslationLocaleProperty(
+        ClassMetadata $baseClassMetadata,
+        TranslatableClassMetadata $translatableClassMetadata
+    ) {
+        if (!$baseClassMetadata->hasField($translatableClassMetadata->localeProperty)
+            && !$baseClassMetadata->hasAssociation($translatableClassMetadata->localeProperty)
+        ) {
             throw new Exception\MappingException(sprintf(
                 "Entity '%s' seems to be a translation entity so its '%s' field must be persistent",
                 $baseClassMetadata->getName(),
@@ -306,14 +309,12 @@ class TranslatableListener extends MappedEventSubscriber
         foreach ($translatableMeta->getTranslationAssociationMetadatas() as $associationMeta) {
 
             $context = $this->getTranslationContext($objectManager, $associationMeta, $object);
-
             $locale = $this->translationHelper->getObjectLocale($context, $object);
             if (!isset($locale)) {
                 $locale = $this->getLocale();
             }
 
             $hasTranslatedProperties = $this->translationHelper->hasTranslatedProperties($context, $object);
-
             if (!isset($locale) && $hasTranslatedProperties) {
                 throw new Exception\RuntimeException(
                     "Neither object's locale nor the current locale was set for translatable properties"

--- a/lib/FSi/DoctrineExtensions/Translatable/TranslatableListener.php
+++ b/lib/FSi/DoctrineExtensions/Translatable/TranslatableListener.php
@@ -306,7 +306,6 @@ class TranslatableListener extends MappedEventSubscriber
         }
 
         foreach ($translatableMeta->getTranslationAssociationMetadatas() as $associationMeta) {
-
             $context = $this->getTranslationContext($objectManager, $associationMeta, $object);
             $locale = $this->translationHelper->getObjectLocale($context, $object);
             if (is_null($locale) || $locale === '') {

--- a/lib/FSi/DoctrineExtensions/Translatable/TranslationHelper.php
+++ b/lib/FSi/DoctrineExtensions/Translatable/TranslationHelper.php
@@ -58,7 +58,7 @@ class TranslationHelper
         $translationAssociationMeta = $context->getAssociationMetadata();
 
         $locale = $this->getObjectLocale($context, $object);
-        if (!isset($locale)) {
+        if (is_null($locale) || $locale === '') {
             $locale = $defaultLocale;
         }
 
@@ -81,16 +81,14 @@ class TranslationHelper
      * @param ClassTranslationContext $context
      * @param object $object
      */
-    public function removeEmptyTranslation(
-        ClassTranslationContext $context,
-        $object
-    ) {
+    public function removeEmptyTranslation(ClassTranslationContext $context, $object)
+    {
         if ($this->hasTranslatedProperties($context, $object)) {
             return;
         }
 
         $objectLocale = $this->getObjectLocale($context, $object);
-        if (!isset($objectLocale)) {
+        if (is_null($objectLocale) || $objectLocale === '') {
             return;
         }
 

--- a/lib/FSi/DoctrineExtensions/Translatable/TranslationHelper.php
+++ b/lib/FSi/DoctrineExtensions/Translatable/TranslationHelper.php
@@ -9,8 +9,6 @@
 
 namespace FSi\DoctrineExtensions\Translatable;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\ObjectManager;
 use FSi\DoctrineExtensions\Translatable\Mapping\ClassMetadata as TranslatableClassMetadata;
 use FSi\DoctrineExtensions\Translatable\Model\TranslatableRepositoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -80,7 +78,6 @@ class TranslationHelper
     }
 
     /**
-     * @param TranslatableRepositoryInterface $translatableRepository
      * @param ClassTranslationContext $context
      * @param object $object
      */
@@ -116,7 +113,7 @@ class TranslationHelper
 
     /**
      * @param ClassTranslationContext $context
-     * @param $object
+     * @param object $object
      */
     public function clearTranslatableProperties(ClassTranslationContext $context, $object)
     {
@@ -147,8 +144,10 @@ class TranslationHelper
 
         foreach ($properties as $property => $translationField) {
             $value = $propertyAccessor->getValue($object, $property);
-            if ($translationMeta->isCollectionValuedAssociation($translationField) && count($value)
-                || !$translationMeta->isCollectionValuedAssociation($translationField) && null !== $value
+            if ($translationMeta->isCollectionValuedAssociation($translationField)
+                && count($value)
+                || !$translationMeta->isCollectionValuedAssociation($translationField)
+                && null !== $value
             ) {
                 return true;
             }
@@ -187,7 +186,6 @@ class TranslationHelper
     private function copyProperties($source, $target, $properties)
     {
         $propertyAccessor = $this->getPropertyAccessor();
-
         foreach ($properties as $sourceField => $targetField) {
             $value = $propertyAccessor->getValue($source, $sourceField);
             $propertyAccessor->setValue($target, $targetField, $value);

--- a/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/Article.php
+++ b/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/Article.php
@@ -173,7 +173,7 @@ class Article
 
     public function getLocale()
     {
-        return $this->locale;
+        return (string) $this->locale;
     }
 
     public function addCategory(Category $category)

--- a/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/Article.php
+++ b/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/Article.php
@@ -10,7 +10,6 @@
 namespace FSi\DoctrineExtensions\Tests\Translatable\Fixture;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Mapping as ORM;
 use FSi\DoctrineExtensions\Translatable\Mapping\Annotation as Translatable;
 
@@ -97,15 +96,6 @@ class Article
     {
         $this->comments = new ArrayCollection();
         $this->translations = new ArrayCollection();
-    }
-
-    /**
-     * @ORM\PostLoad()
-     * @param \Doctrine\ORM\Event\LifecycleEventArgs $eventArgs
-     */
-    public function postLoad(LifecycleEventArgs $eventArgs)
-    {
-        $this->comments = new ArrayCollection();
     }
 
     /**

--- a/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/ArticleTranslation.php
+++ b/tests/FSi/DoctrineExtensions/Tests/Translatable/Fixture/ArticleTranslation.php
@@ -172,6 +172,7 @@ class ArticleTranslation
      */
     public function addComment(Comment $comment)
     {
+        $comment->setArticleTranslation($this);
         $this->comments->add($comment);
     }
 
@@ -181,6 +182,7 @@ class ArticleTranslation
     public function removeComment(Comment $comment)
     {
         $this->comments->removeElement($comment);
+        $comment->setArticleTranslation(null);
     }
 
     /**

--- a/tests/FSi/DoctrineExtensions/Tests/Translatable/ListenerTest.php
+++ b/tests/FSi/DoctrineExtensions/Tests/Translatable/ListenerTest.php
@@ -548,6 +548,30 @@ class ListenerTest extends BaseTranslatableTest
     }
 
     /**
+     * Assert that an empty string returned in Article::getLocale() will not mask
+     * the fact that no locale was set for either the listener or the entity.
+     */
+    public function testCurrentLocaleSetToNull()
+    {
+        $this->_translatableListener->setDefaultLocale($this->_languagePl);
+        $this->_translatableListener->setLocale(null);
+
+        $article = new Article();
+        $article->setDate(new \DateTime());
+        $article->setLocale(null);
+        $article->setTitle(self::POLISH_TITLE_1);
+        $article->setContents(self::POLISH_CONTENTS_1);
+
+        $this->setExpectedException(
+            "\FSi\DoctrineExtensions\Translatable\Exception\RuntimeException",
+            "Neither object's locale nor the current locale was set for translatable properties"
+        );
+
+        $this->_em->persist($article);
+        $this->_em->flush();
+    }
+
+    /**
      * Test entity creation with two translation and check its state after $em->clear(), change default locale and load with some
      * specific translation
      */


### PR DESCRIPTION
Resolves #67 

TODO:
- [x] Remove docs entries regarding using `postLoad` to fix this issue