### PR TITLE
Fixed XML mapping validation.

### DIFF
--- a/lib/FSi/DoctrineExtensions/Mapping/Driver/AbstractXmlDriver.php
+++ b/lib/FSi/DoctrineExtensions/Mapping/Driver/AbstractXmlDriver.php
@@ -98,8 +98,10 @@ abstract class AbstractXmlDriver extends AbstractFileDriver
                 continue;
             }
 
-            foreach ($dom->getElementsByTagNameNS($xmlns->nodeValue, '*') as $elem) {
-                $elem->parentNode->removeChild($elem);
+            $domNodeList = $dom->getElementsByTagNameNS($xmlns->nodeValue, '*');
+            for ($i = $domNodeList->length; --$i >= 0; ) {
+                $element = $domNodeList->item($i);
+                $element->parentNode->removeChild($element);
             }
         }
 


### PR DESCRIPTION
```
Warning: DOMDocument::schemaValidateSource(): Element '{http://gediminasm.org/schemas/orm/doctrine-extensions-mapping}sortable-position': No matching global element declaration available,
but demanded by the strict wildcard.
```

https://github.com/fsi-open/doctrine-extensions/pull/108