### PR TITLE
SplFileInfoHandler should handle empty files 

### DIFF
--- a/lib/FSi/DoctrineExtensions/Uploadable/FileHandler/SplFileInfoHandler.php
+++ b/lib/FSi/DoctrineExtensions/Uploadable/FileHandler/SplFileInfoHandler.php
@@ -120,6 +120,10 @@ class SplFileInfoHandler extends AbstractHandler
 
     private function tryReadFile(SplFileObject $fileObject, int $length): string
     {
+        if ($length === 0) {
+            return '';
+        }
+
         $content = $fileObject->fread($length);
 
         if (false === $content) {

--- a/tests/FSi/DoctrineExtensions/Tests/Uploadable/FileHandler/SplFileInfoHandlerTest.php
+++ b/tests/FSi/DoctrineExtensions/Tests/Uploadable/FileHandler/SplFileInfoHandlerTest.php
@@ -41,6 +41,14 @@ class SplFileInfoHandlerTest extends BaseHandlerTest
         $this->assertEquals(self::CONTENT, $content);
     }
 
+    public function testGetContentOnEmptyFile()
+    {
+        $emptyFile = new SplTempFileObject();
+
+        $content = $this->handler->getContent($emptyFile);
+        $this->assertEquals('', $content);
+    }
+
     public function testGetContentOnTempFile()
     {
         $input = new SplTempFileObject();


### PR DESCRIPTION
(SplFileObject::fread(): Length parameter must be greater than 0").